### PR TITLE
Cleanup of model arguments to inference functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ sys
 *.csv
 *.dat                  
 !paper.pdf
+!.github
+.*

--- a/examples/HMM.hs
+++ b/examples/HMM.hs
@@ -59,7 +59,7 @@ simulateHMM = do
   let x_0 = 0; n = 10
   -- Specify model environment
       env = #trans_p := [0.5] <:> #obs_p := [0.8] <:> #y := [] <:> nil
-  SIM.simulate (hmmFor n) env 0
+  SIM.simulate (hmmFor n x_0) env
 
 -- | Perform likelihood-weighting inference over HMM
 inferLwHMM :: Sampler  [(Env HMMEnv, Double)]
@@ -68,7 +68,7 @@ inferLwHMM   = do
   let x_0 = 0; n = 10
   -- Specify model environment
       env = #trans_p := [] <:> #obs_p := [] <:> #y := [0, 1, 1, 3, 4, 5, 5, 5, 6, 5] <:> nil
-  LW.lw 100 (hmmFor n) (x_0, env)
+  LW.lw 100 (hmmFor n x_0) env
 
 {- | A modular HMM.
 -}

--- a/examples/LDA.hs
+++ b/examples/LDA.hs
@@ -126,7 +126,7 @@ simLDA = do
                       [1.72605174564027e-2,2.9475900240868515e-2,9.906011619752661e-2,0.8542034661052021]] <:>
                #w := [] <:> nil
   -- Simulate from topic model
-  (words, env_out) <- SIM.simulate (topicModel vocab n_topics) env_in n_words
+  (words, env_out) <- SIM.simulate (topicModel vocab n_topics n_words) env_in
   return words
 
 -- | Example document of words
@@ -142,7 +142,7 @@ mhLDA  = do
   -- Specify model environment
       env_mh_in = #θ := [] <:>  #φ := [] <:> #w := topic_data <:> nil
   -- Run MH for 500 iterations
-  env_mh_outs <- MH.mh 500 (topicModel vocab n_topics) (n_words, env_mh_in) ["φ", "θ"]
+  env_mh_outs <- MH.mh 500 (topicModel vocab n_topics n_words) env_mh_in ["φ", "θ"]
   -- Draw the most recent sampled parameters from the MH trace
   let env_pred   = head env_mh_outs
       θs         = get #θ env_pred

--- a/examples/LinRegr.hs
+++ b/examples/LinRegr.hs
@@ -51,7 +51,7 @@ simulateLinRegr = do
   -- Specify model environment
       env = (#m := [3.0]) <:> (#c := [0]) <:> (#σ := [1]) <:> (#y := []) <:> nil
   -- Simulate linear regression for each input x
-  ys_envs <- mapM (SIM.simulate linRegr env) xs
+  ys_envs <- mapM (\x -> SIM.simulate (linRegr x) env) xs
   let ys = map fst ys_envs
   return (zip xs ys)
 
@@ -61,9 +61,9 @@ inferLwLinRegr = do
   -- Specify model inputs
   let xs  = [0 .. 100]
   -- Specify model environments and pair with model input
-      xys = [(x, env) | x <- xs, let env = (#m := []) <:> (#c := []) <:> (#σ := []) <:> (#y := [3*x]) <:> nil]
+      x_envs = [(x, env) | x <- xs, let env = (#m := []) <:> (#c := []) <:> (#σ := []) <:> (#y := [3*x]) <:> nil]
   -- Run LW for 20 iterations on each pair of model input and environment
-  lwTrace <- mapM (LW.lw 20 linRegr) xys
+  lwTrace <- mapM (\(x, env) -> LW.lw 20 (linRegr x) env) x_envs
    -- Get the sampled values of mu and their likelihood-weighting
   let (env_outs, ps) = unzip $ concat lwTrace
       mus = concatMap (get #m) env_outs
@@ -75,9 +75,9 @@ inferMhLinRegr = do
   -- Specify model inputs
   let xs  = [0 .. 100]
   -- Specify model environments and pair with model input
-      xys = [(x, env) | x <- xs, let env = (#m := []) <:> (#c := []) <:> (#σ := []) <:> (#y := [3*x]) <:> nil]
+      x_envs = [(x, env) | x <- xs, let env = (#m := []) <:> (#c := []) <:> (#σ := []) <:> (#y := [3*x]) <:> nil]
   -- Run MH for 100 iterations on each pair of model input and environment
-  mhTrace <- concat <$> mapM (\xy -> MH.mh 100 linRegr xy ["m", "c"]) xys
+  mhTrace <- concat <$> mapM (\(x, env) -> MH.mh 100 (linRegr x) env ["m", "c"]) x_envs
   -- Get the sampled values of mu
   let mus = concatMap (get #m) mhTrace
   return mus

--- a/examples/LogRegr.hs
+++ b/examples/LogRegr.hs
@@ -67,7 +67,7 @@ simulateLogRegr = do
   -- Define a model environment to simulate from, providing observed values for the model parameters
       env = (#y := []) <:> (#m := [2]) <:> (#b := [-0.15]) <:> nil
   -- Call simulate on logistic regression
-  (ys, envs) <- SIM.simulate logRegr env xs
+  (ys, envs) <- SIM.simulate (logRegr xs) env
   return (zip xs ys)
 
 -- | Likelihood-weighting over logistic regression
@@ -78,7 +78,7 @@ inferLwLogRegr = do
   -- Define environment for inference, providing observed values for the model outputs
   let env = (#y := ys) <:> (#m := []) <:> (#b := []) <:> nil
   -- Run LW inference for 20000 iterations
-  lwTrace :: [(Env LogRegrEnv, Double)] <- LW.lw 20000 logRegr (xs, env)
+  lwTrace :: [(Env LogRegrEnv, Double)] <- LW.lw 20000 (logRegr xs) env
   let -- Get output of LW, extract mu samples, and pair with likelihood-weighting ps
       (env_outs, ps) = unzip lwTrace
       mus = concatMap (get #m) env_outs
@@ -94,7 +94,7 @@ inferMHLogRegr = do
   -- Run MH inference for 20000 iterations
   {- The agument ["m", "b"] is optional for indicating interest in learning #m and #b in particular,
      causing other variables to not be resampled (unless necessary) during MH. -}
-  mhTrace :: [Env LogRegrEnv] <- MH.mh 50000 logRegr (xs, env) ["m", "b"]
+  mhTrace :: [Env LogRegrEnv] <- MH.mh 50000 (logRegr xs) env ["m", "b"]
   -- Retrieve values sampled for #m and #b during MH
   let m_samples = concatMap (get #m) mhTrace
       b_samples = concatMap (get #b) mhTrace

--- a/examples/SIR.hs
+++ b/examples/SIR.hs
@@ -120,7 +120,7 @@ simulateSIR = do
   -- Specify model environment
       sim_env_in = #β := [0.7] <:> #γ := [0.009] <:> #ρ := [0.3] <:> #𝜉 := [] <:> nil
   -- Simulate an epidemic over 100 days
-  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIR 100) sim_env_in sir_0
+  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIR 100 sir_0) sim_env_in
   -- Get the observed infections over 100 days
   let 𝜉s :: [Reported] = get #𝜉 sim_env_out
   -- Get the true SIR values over 100 days
@@ -137,7 +137,7 @@ inferSIR = do
   -- Specify model environment
       mh_env_in = #β := [] <:> #γ := [0.0085] <:> #ρ := [] <:> #𝜉 := 𝜉s <:> nil
   -- Run MH inference over 5000 iterations
-  mhTrace <- MH.mh 5000 (hmmSIR 100) (sir_0, mh_env_in) ["β", "ρ"]
+  mhTrace <- MH.mh 5000 (hmmSIR 100 sir_0) mh_env_in ["β", "ρ"]
   -- Get the sampled values for model parameters ρ and β
   let ρs = concatMap (get #ρ) mhTrace
       βs = concatMap (get #β) mhTrace
@@ -180,7 +180,7 @@ simulateSIRS = do
   -- Specify model environment
       sim_env_in = #β := [0.7] <:> #γ := [0.009] <:> #η := [0.05] <:> #ρ := [0.3] <:> #𝜉 := [] <:> nil
   -- Simulate an epidemic over 100 days
-  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIRS 100) sim_env_in sir_0
+  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIRS 100 sir_0) sim_env_in
   -- Get the observed infections over 100 days
   let 𝜉s :: [Reported] = get #𝜉 sim_env_out
   -- Get the true SIRS values over 100 days
@@ -226,7 +226,7 @@ simulateSIRSV = do
   -- Specify model environment
       sim_env_in = #β := [0.7] <:> #γ := [0.009] <:> #η := [0.05] <:> #ω := [0.02] <:> #ρ := [0.3] <:> #𝜉 := [] <:> nil
   -- Simulate an epidemic over 100 days
-  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIRSV 100) sim_env_in sir_0
+  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIRSV 100 sir_0) sim_env_in
   -- Get the observed infections over 100 days
   let 𝜉s :: [Reported] = get #𝜉 sim_env_out
   -- Get the true SIRSV values over 100 days

--- a/examples/SIRNonModular.hs
+++ b/examples/SIRNonModular.hs
@@ -124,7 +124,7 @@ simulateSIR = do
   -- Specify model environment
       sim_env_in = #β := [0.7] <:> #γ := [0.009] <:> #ρ := [0.3] <:> #𝜉 := [] <:> nil
   -- Simulate an epidemic over 100 days
-  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIR' 100) sim_env_in sir_0
+  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIR' 100 sir_0) sim_env_in
   -- Get the observed infections over 100 days
   let 𝜉s :: [Reported] = get #𝜉 sim_env_out
   -- Get the true SIR values over 100 days
@@ -141,7 +141,7 @@ inferSIR = do
   -- Specify model environment
       mh_env_in = #β := [] <:> #γ := [0.0085] <:> #ρ := [] <:> #𝜉 := 𝜉s <:> nil
   -- Run MH inference over 50000 iterations
-  mhTrace <- MH.mh 5000 (hmmSIR' 100) (sir_0, mh_env_in) ["β", "ρ"]
+  mhTrace <- MH.mh 5000 (hmmSIR' 100 sir_0) mh_env_in ["β", "ρ"]
   -- Get the sampled values for model parameters ρ and β
   let ρs = concatMap (get #ρ) mhTrace
       βs = concatMap (get #β) mhTrace
@@ -191,7 +191,7 @@ simulateSIRS = do
   -- Specify model environment
       sim_env_in = #β := [0.7] <:> #γ := [0.009] <:> #η := [0.05] <:> #ρ := [0.3] <:> #𝜉 := [] <:> nil
   -- Simulate an epidemic over 100 days
-  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIRS 100) sim_env_in sir_0
+  ((_, sir_trace), sim_env_out) <- SIM.simulate (hmmSIRS 100 sir_0) sim_env_in
   -- Get the observed infections over 100 days
   let 𝜉s :: [Reported] = get #𝜉 sim_env_out
   -- Get the true SIR values over 100 days
@@ -279,7 +279,7 @@ simulateSIRSV = do
   -- Specify model environment
       sim_env_in = #β := [0.7] <:> #γ := [0.009] <:> #η := [0.05] <:> #ω := [0.02] <:> #ρ := [0.3] <:> #𝜉 := [] <:> nil
   -- Simulate an epidemic over 100 days
-  ((_, sirv_trace), sim_env_out) <- SIM.simulate (hmmSIRSV 100) sim_env_in sirv_0
+  ((_, sirv_trace), sim_env_out) <- SIM.simulate (hmmSIRSV 100 sirv_0) sim_env_in
   -- Get the observed infections over 100 days
   let 𝜉s :: [Reported] = get #𝜉 sim_env_out
   -- Get the true SIRV values over 100 days

--- a/examples/School.hs
+++ b/examples/School.hs
@@ -52,7 +52,7 @@ mhSchool = do
   -- Specify model environment
       env       = #mu := [] <:> #theta := [] <:> #y := ys <:> ENil
   -- Run MH inference for 10000 iterations
-  env_mh_out <- MH.mh 10000 (schoolModel n_schools ) (sigmas, env) ["mu", "theta"]
+  env_mh_out <- MH.mh 10000 (schoolModel n_schools sigmas) env ["mu", "theta"]
   -- Retrieve and returns the trace of model parameters mu and theta
   let mus    = concatMap (get #mu) env_mh_out
       thetas = concatMap (get #theta) env_mh_out

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -84,8 +84,8 @@ instance Monad (Model env es) where
 
 {- | The initial handler for models, specialising a model under a certain
 environment to produce a probabilistic program consisting of @Sample@ and @Observe@ operations. -}
-handleCore :: (Member Observe es, Member Sample es) => Env env -> Model env (ObsReader env : Dist : es) a -> Prog es a
-handleCore env m = (handleDist . handleRead env) (runModel m)
+handleCore :: (Member Observe es, Member Sample es) => Model env (ObsReader env : Dist : es) a -> Env env -> Prog es a
+handleCore m env = (handleDist . handleRead env) (runModel m)
 
 {- $Smart-Constructors
 


### PR DESCRIPTION
## Description
Removed the single-arg model function arguments in favor of just providing a model in inference functions

## Goals
- *code cleanup*

## Changes
- [x] *Remove (b -> Model env es a) pattern from inference functions*
- [x] *Set a consistent ordering of (model, env) in inference functions*
- [x] *Update examples with the changed interface*