### PR TITLE
Changed `-- |` comments to `-- ^` as per haddock specification

### DIFF
--- a/src/Effects/State.hs
+++ b/src/Effects/State.hs
@@ -37,11 +37,9 @@ modify f = get >>= put . f
 
 -- | Handle the @State s@ effect
 handleState
-  -- | initial state
-  :: s
+  :: s -- ^ initial state
   -> Prog (State s ': es) a
-  -- | (output, final state)
-  -> Prog es (a, s)
+  -> Prog es (a, s) -- ^ (output, final state)
 handleState s m = loop s m where
   loop :: s -> Prog (State s ': es) a -> Prog es (a, s)
   loop s (Val x) = return (x, s)

--- a/src/Effects/Writer.hs
+++ b/src/Effects/Writer.hs
@@ -34,8 +34,7 @@ tellM w = Model $ tell w
 -- | Handle the @Writer@ effect for a stream @w@
 handleWriter :: forall w es a. Monoid w
   => Prog (Writer w ': es) a
-  -- | (output, final stream)
-  -> Prog es (a, w)
+  -> Prog es (a, w) -- ^ (output, final stream)
 handleWriter = loop mempty where
   loop ::  w -> Prog (Writer w ': es) a -> Prog es (a, w)
   loop w (Val x) = return (x, w)
@@ -46,6 +45,5 @@ handleWriter = loop mempty where
 -- | Handle the @Writer@ effect inside a @Model@
 handleWriterM :: Monoid w
   => Model env (Writer w : es) a
-  -- | (output, final stream)
-  -> Model env es (a, w)
+  -> Model env es (a, w) -- ^ (output, final stream)
 handleWriterM m = Model $ handleWriter $ runModel m

--- a/src/Inference/MH.hs
+++ b/src/Inference/MH.hs
@@ -44,17 +44,12 @@ import Unsafe.Coerce ( unsafeCoerce )
 
 -- | Top-level wrapper for Metropolis-Hastings (MH) inference
 mh :: (FromSTrace env, es ~ '[ObsReader env, Dist, State STrace, State LPTrace, Observe, Sample])
-  -- | number of MH iterations
-  => Int
-  -- | model awaiting an input
-  -> Model env es a
-  -- | (model input, input model environment)
-  -> Env env
-  -- | optional list of observable variable names (strings) to specify sample sites of interest
-  {- For example, provide "mu" to specify interest in sampling #mu. This causes other variables to not be resampled unless necessary. -}
-  -> [Tag]
-  -- | [output model environment]
-  -> Sampler [Env env]
+  => Int            -- ^ number of MH iterations
+  -> Model env es a -- ^ model awaiting an input
+  -> Env env        -- ^ (model input, input model environment)
+  -> [Tag] -- ^ optional list of observable variable names (strings) to specify sample sites of interest
+           {- For example, provide "mu" to specify interest in sampling #mu. This causes other variables to not be resampled unless necessary. -}
+  -> Sampler [Env env] -- ^ [output model environment]
 mh n model env_0 tags = do
   -- Perform initial run of MH with no proposal sample site
   y0 <- runMH model env_0 Map.empty ("", 0)
@@ -65,16 +60,11 @@ mh n model env_0 tags = do
 
 -- | Perform one step of MH
 mhStep :: (es ~ '[ObsReader env, Dist, State STrace, State LPTrace, Observe, Sample])
-  -- | model
-  => Model env es a
-  -- | model environment
-  -> Env env
-  -- | tags indicating sample sites of interest
-  -> [Tag]
-  -- | trace of previous MH outputs
-  -> [((a, STrace), LPTrace)]
-  -- | updated trace of MH outputs
-  -> Sampler [((a, STrace), LPTrace)]
+  => Model env es a           -- ^ model
+  -> Env env                  -- ^ model environment
+  -> [Tag]                    -- ^ tags indicating sample sites of interest
+  -> [((a, STrace), LPTrace)] -- ^ trace of previous MH outputs
+  -> Sampler [((a, STrace), LPTrace)] -- ^ updated trace of MH outputs
 mhStep model env tags trace = do
   -- Get previous mh output
   let ((x, samples), logps) = head trace
@@ -95,16 +85,11 @@ mhStep model env tags trace = do
 
 -- | Handler for one iteration of MH
 runMH :: (es ~ '[ObsReader env, Dist, State STrace, State LPTrace, Observe, Sample])
-  -- | model
-  => Model env es a
-  -- | model environment
-  -> Env env
-  -- | sample trace of previous MH iteration
-  -> STrace
-  -- | sample address of interest
-  -> Addr
-  -- | (model output, sample trace, log-probability trace)
-  -> Sampler ((a, STrace), LPTrace)
+  => Model env es a -- ^ model
+  -> Env env        -- ^ model environment
+  -> STrace         -- ^ sample trace of previous MH iteration
+  -> Addr           -- ^ sample address of interest
+  -> Sampler ((a, STrace), LPTrace) -- ^ (model output, sample trace, log-probability trace)
 runMH model env strace α_samp =
      handleSamp strace α_samp $ handleObs
    $ handleState Map.empty $ handleState Map.empty
@@ -127,10 +112,8 @@ traceLPs (Op op k) = case op of
 
 -- | Handler for @Sample@ that selectively reuses old samples or draws new ones
 handleSamp ::
-  -- | sample trace
-     STrace
-  -- | address of the proposal sample site for the current MH iteration
-  -> Addr
+     STrace -- ^ sample trace
+  -> Addr   -- ^ address of the proposal sample site for the current MH iteration
   -> Prog '[Sample] a
   -> Sampler a
 handleSamp strace α_samp (Op op k) = case discharge op of
@@ -144,14 +127,10 @@ handleSamp _ _ (Val x) = return x
 --   it only if the primitive distribution it was sampled from matches the current one.
 lookupSample :: OpenSum.Member a PrimVal
   =>
-  -- | sample trace
-     STrace
-  -- | distribution to sample from
-  -> PrimDist a
-  -- | address of current sample site
-  -> Addr
-  -- | address of proposal sample site
-  -> Addr
+     STrace     -- ^ sample trace
+  -> PrimDist a -- ^ distribution to sample from
+  -> Addr       -- ^ address of current sample site
+  -> Addr       -- ^ address of proposal sample site
   -> Sampler a
 lookupSample samples d α α_samp
   | α == α_samp = sample d
@@ -164,17 +143,11 @@ lookupSample samples d α α_samp
         Nothing -> sample d
 
 -- | Compute acceptance probability
-accept ::
-  -- | address of new sampled value
-     Addr
-  -- | previous MH sample trace
-  -> STrace
-  -- | new MH sample trace
-  -> STrace
-  -- | previous MH log-probability trace
-  -> LPTrace
-  -- | current MH log-probability trace
-  -> LPTrace
+accept :: Addr -- ^ address of new sampled value
+  -> STrace    -- ^ previous MH sample trace
+  -> STrace    -- ^ new MH sample trace
+  -> LPTrace   -- ^ previous MH log-probability trace
+  -> LPTrace   -- ^ current MH log-probability trace
   -> IO Double
 accept x0 _Ⲭ _Ⲭ' logℙ logℙ' = do
   let _X'sampled = Set.singleton x0 `Set.union` (Map.keysSet _Ⲭ' \\ Map.keysSet _Ⲭ)

--- a/src/Inference/SIM.hs
+++ b/src/Inference/SIM.hs
@@ -33,24 +33,18 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -- | Top-level wrapper for simulating from a model
 simulate :: (FromSTrace env, es ~ '[ObsReader env, Dist,State STrace, Observe, Sample])
-  -- | model
-  => Model env es a
-  -- | model environment
-  -> Env env
-  -- | (model output, output environment)
-  -> Sampler (a, Env env)
+  => Model env es a       -- ^ model
+  -> Env env              -- ^ model environment
+  -> Sampler (a, Env env) -- ^ (model output, output environment)
 simulate model env = do
   (output, strace) <- runSimulate model env
   return (output, fromSTrace strace)
 
 -- | Handler for simulating once from a probabilistic program
 runSimulate :: (es ~ '[ObsReader env, Dist, State STrace, Observe, Sample])
- -- | model
- => Model env es a
- -- | model environment
- -> Env env
- -- | (model output, sample trace)
- -> Sampler (a, STrace)
+ => Model env es a      -- ^ model
+ -> Env env             -- ^ model environment
+ -> Sampler (a, STrace) -- ^ (model output, sample trace)
 runSimulate model
   = handleSamp . handleObs . handleState Map.empty . traceSamples . handleCore model
 

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -119,8 +119,7 @@ deterministic x field = Model $ do
   call (Dist (DeterministicDist x) maybe_y tag)
 
 deterministic' :: (Eq a, Show a, OpenSum.Member a PrimVal) =>
-  -- | value to be deterministically generated
-     a
+     a -- ^ value to be deterministically generated
   -> Model env es a
 deterministic' x = Model $ do
   call (Dist (DeterministicDist x) Nothing Nothing)
@@ -135,8 +134,7 @@ dirichlet xs field = Model $ do
   call (Dist (DirichletDist xs) maybe_y tag)
 
 dirichlet' ::
-  -- | concentration parameters
-     [Double]
+     [Double] -- ^ concentration parameters
   -> Model env es [Double]
 dirichlet' xs = Model $ do
   call (Dist (DirichletDist xs) Nothing Nothing)
@@ -151,10 +149,8 @@ discrete ps field = Model $ do
   call (Dist (DiscreteDist ps) maybe_y tag)
 
 discrete' ::
-  -- | list of @n@ probabilities
-     [Double]
-  -- | integer index from @0@ to @n - 1@
-  -> Model env es Int
+     [Double]         -- ^ list of @n@ probabilities
+  -> Model env es Int -- ^ integer index from @0@ to @n - 1@
 discrete' ps = Model $ do
   call (Dist (DiscreteDist ps) Nothing Nothing)
 
@@ -168,8 +164,7 @@ categorical xs field = Model $ do
   call (Dist (CategoricalDist xs) maybe_y tag)
 
 categorical' :: (Eq a, Show a, OpenSum.Member a PrimVal) =>
-  -- | primitive values and their probabilities
-     [(a, Double)]
+     [(a, Double)] -- ^ primitive values and their probabilities
   -> Model env es a
 categorical' xs = Model $ do
   call (Dist (CategoricalDist xs) Nothing Nothing)
@@ -185,10 +180,8 @@ normal mu sigma field = Model $ do
   call (Dist (NormalDist mu sigma) maybe_y tag)
 
 normal' ::
-  -- | mean
-     Double
-  -- | standard deviation
-  -> Double
+     Double -- ^ mean
+  -> Double -- ^ standard deviation
   -> Model env es Double
 normal' mu sigma = Model $ do
   call (Dist (NormalDist mu sigma) Nothing Nothing)
@@ -203,8 +196,7 @@ halfNormal sigma field = Model $ do
   call (Dist (HalfNormalDist sigma) maybe_y tag)
 
 halfNormal' ::
-  -- | standard deviation
-     Double
+     Double -- ^ standard deviation
   -> Model env es Double
 halfNormal' sigma = Model $ do
   call (Dist (HalfNormalDist sigma) Nothing Nothing)
@@ -220,10 +212,8 @@ cauchy mu sigma field = Model $ do
   call (Dist (CauchyDist mu sigma) maybe_y tag)
 
 cauchy' ::
-  -- | location
-     Double
-  -- | scale
-  -> Double
+     Double -- ^ location
+  -> Double -- ^ scale
   -> Model env es Double
 cauchy' mu sigma = Model $ do
   call (Dist (CauchyDist mu sigma) Nothing Nothing)
@@ -238,8 +228,7 @@ halfCauchy sigma field = Model $ do
   call (Dist (HalfCauchyDist sigma) maybe_y tag)
 
 halfCauchy' ::
-  -- | scale
-     Double
+     Double -- ^ scale
   -> Model env es Double
 halfCauchy' sigma = Model $ do
   call (Dist (HalfCauchyDist sigma) Nothing Nothing)
@@ -254,8 +243,7 @@ bernoulli p field = Model $ do
   call (Dist (BernoulliDist p) maybe_y tag)
 
 bernoulli' ::
-  -- | probability of @True@
-     Double
+     Double -- ^ probability of @True@
   -> Model env es Bool
 bernoulli' p = Model $ do
   call (Dist (BernoulliDist p) Nothing Nothing)
@@ -271,10 +259,8 @@ beta α β field = Model $ do
   call (Dist (BetaDist α β) maybe_y tag)
 
 beta' ::
-  -- | shape 1 (α)
-     Double
-  -- | shape 2 (β)
-  -> Double
+     Double -- ^ shape 1 (α)
+  -> Double -- ^ shape 2 (β)
   -> Model env es Double
 beta' α β = Model $ do
   call (Dist (BetaDist α β) Nothing Nothing)
@@ -290,12 +276,9 @@ binomial n p field = Model $ do
   call (Dist (BinomialDist n p) maybe_y tag)
 
 binomial' ::
-  -- | number of trials
-     Int
-  -- | probability of successful trial
-  -> Double
-  -- | number of successful trials
-  -> Model env es Int
+     Int              -- ^ number of trials
+  -> Double           -- ^ probability of successful trial
+  -> Model env es Int -- ^ number of successful trials
 binomial' n p = Model $ do
   call (Dist (BinomialDist n p) Nothing Nothing)
 
@@ -310,10 +293,8 @@ gamma k θ field = Model $ do
   call (Dist (GammaDist k θ) maybe_y tag)
 
 gamma' ::
-  -- | shape (k)
-     Double
-  -- | scale (θ)
-  -> Double
+     Double -- ^ shape (k)
+  -> Double -- ^ scale (θ)
   -> Model env es Double
 gamma' k θ = Model $ do
   call (Dist (GammaDist k θ) Nothing Nothing)
@@ -329,10 +310,8 @@ uniform min max field = Model $ do
   call (Dist (UniformDist min max) maybe_y tag)
 
 uniform' ::
-  -- | lower-bound
-     Double
-  -- | upper-bound
-  -> Double
+     Double -- ^ lower-bound
+  -> Double -- ^ upper-bound
   -> Model env es Double
 uniform' min max = Model $ do
   call (Dist (UniformDist min max) Nothing Nothing)
@@ -347,10 +326,8 @@ poisson λ field = Model $ do
   call (Dist (PoissonDist λ) maybe_y tag)
 
 poisson' ::
-  -- | rate (λ)
-     Double
-  -- | number of events
-  -> Model env es Int
+     Double           -- ^ rate (λ)
+  -> Model env es Int -- ^ number of events
 poisson' λ = Model $ do
   call (Dist (PoissonDist λ) Nothing Nothing)
 

--- a/src/PrimDist.hs
+++ b/src/PrimDist.hs
@@ -221,12 +221,9 @@ sample (DeterministicDist x) = pure x
 
 -- | Compute the density of a primitive distribution generating an observed value
 prob ::
-  -- | distribution
-     PrimDist a
-  -- | observed value
-  -> a
-  -- | density
-  -> Double
+     PrimDist a -- ^ distribution
+  -> a          -- ^ observed value
+  -> Double     -- ^ density
 prob (DirichletDist xs) ys
   | Prelude.sum xs' /= 1 = error "dirichlet can't normalize"
   | otherwise 
@@ -266,11 +263,7 @@ prob (PoissonDist λ) y       = probability (poisson λ) y
 prob (DeterministicDist x) y = 1
 
 -- | Compute the log density of a primitive distribution generating an observed value
-logProb ::
-  -- | distribution
-     PrimDist a
-  -- | observed value
-  -> a
-  -- | log density
-  -> Double
+logProb :: PrimDist a -- ^ distribution
+  -> a                -- ^ observed value
+  -> Double           -- ^ log density
 logProb d = log . prob d

--- a/src/Trace.hs
+++ b/src/Trace.hs
@@ -54,16 +54,11 @@ extractSamples (x, typ)  =
 
 -- | Update a sample trace at an address
 updateSTrace :: (Show x, OpenSum.Member x PrimVal) =>
-  -- | address of sample site
-     Addr
-  -- | primitive distribution at address
-  -> PrimDist x
-  -- | sampled value
-  -> x
-  -- | previous sample trace
-  -> STrace
-  -- | updated sample trace
-  -> STrace
+     Addr       -- ^ address of sample site
+  -> PrimDist x -- ^ primitive distribution at address
+  -> x          -- ^ sampled value
+  -> STrace     -- ^ previous sample trace
+  -> STrace     -- ^ updated sample trace
 updateSTrace α d x = Map.insert α (ErasedPrimDist d, OpenSum.inj x)
 
 {- | The type of log-probability traces, mapping addresses of sample/observe operations
@@ -73,14 +68,9 @@ type LPTrace = Map Addr Double
 
 -- | Compute and update a log-probability trace at an address
 updateLPTrace ::
-  -- | address of sample/observe site
-     Addr
-  -- | primitive distribution at address
-  -> PrimDist x
-  -- | sampled or observed value
-  -> x
-  -- | previous log-prob trace
-  -> LPTrace
-  -- | updated log-prob trace
-  -> LPTrace
+     Addr       -- ^ address of sample/observe site
+  -> PrimDist x -- ^ primitive distribution at address
+  -> x          -- ^ sampled or observed value
+  -> LPTrace    -- ^ previous log-prob trace
+  -> LPTrace    -- ^ updated log-prob trace
 updateLPTrace α d x = Map.insert α (logProb d x)


### PR DESCRIPTION
Signed-off-by: barci2 <bcieslar2001@gmail.com>

## Description
fixes to wrongly formatted function argument comments, which was preventing cabal from building the project for ghc-8.10.x

## Goals
- *make the project build with ghc-8.10.x*

## Changes
- [x] *Changed `-- |` comments to `-- ^` wherever haddock was complaining*